### PR TITLE
[Mistral] Add tekken tokenizer detection, conversion, and save utilities

### DIFF
--- a/src/transformers/integrations/mistral/__init__.py
+++ b/src/transformers/integrations/mistral/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Mistral native format integration: tokenizer conversion utilities."""
+"""Mistral native format integration: config, weight, and tokenizer conversion."""
 
 from typing import TYPE_CHECKING
 
@@ -20,11 +20,23 @@ from ...utils import _LazyModule
 
 
 _import_structure = {
-    "tokenizer": ["MistralConverter"],
+    "tokenizer": [
+        "MistralConverter",
+        "convert_tekken_image_processor",
+        "convert_tekken_tokenizer",
+        "resolve_mistral_format",
+        "save_as_tekken",
+    ],
 }
 
 if TYPE_CHECKING:
-    from .tokenizer import MistralConverter
+    from .tokenizer import (
+        MistralConverter,
+        convert_tekken_image_processor,
+        convert_tekken_tokenizer,
+        resolve_mistral_format,
+        save_as_tekken,
+    )
 else:
     import sys
 

--- a/src/transformers/integrations/mistral/tokenizer.py
+++ b/src/transformers/integrations/mistral/tokenizer.py
@@ -16,16 +16,98 @@
 
 import base64
 import json
+import os
 from functools import lru_cache
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from tokenizers import AddedToken, Regex, Tokenizer, decoders, pre_tokenizers, processors
 from tokenizers.models import BPE
 
 from ...convert_slow_tokenizer import bytes_to_unicode
-from ...utils import logging
+from ...tokenization_utils_tokenizers import PreTrainedTokenizerFast
+from ...utils import cached_file, logging
+from ...utils.import_utils import is_mistral_common_available
 
+
+if TYPE_CHECKING:
+    from ...models.pixtral.processing_pixtral import PixtralProcessor
 
 logger = logging.get_logger(__name__)
+
+
+def resolve_mistral_format(
+    pretrained_model_name_or_path: str | os.PathLike,
+    mistral_format: bool | None = None,
+    **cache_kwargs,
+) -> tuple[bool, str | None]:
+    """Resolve whether to use `MistralCommonBackend` for tokenization.
+
+    Probes for `tekken.json` in the checkpoint directory and checks whether
+    `mistral-common` is installed to determine the appropriate tokenizer backend.
+
+    Args:
+        pretrained_model_name_or_path (`str` or `os.PathLike`):
+            This can be either:
+
+            - a string, the *model id* of a pretrained model hosted on huggingface.co.
+            - a path to a *directory* containing model files.
+        mistral_format (`bool`, *optional*):
+            Tri-state control for tokenizer backend selection:
+
+            - `True` — force `MistralCommonBackend` (raises `ImportError` if `mistral-common`
+              is not installed, raises `OSError` if `tekken.json` is not found).
+            - `False` — force standard HuggingFace tokenizer.
+            - `None` — auto-detect based on `tekken.json` presence and `mistral-common`
+              availability.
+        **cache_kwargs:
+            Forwarded to [`~utils.cached_file`] (e.g. `cache_dir`, `force_download`,
+            `local_files_only`, `revision`, `token`).
+
+    Returns:
+        `tuple[bool, str | None]`: A tuple of `(use_mistral_format, tekken_file_path)` where
+        `use_mistral_format` indicates whether `MistralCommonBackend` should be used, and
+        `tekken_file_path` is the resolved path to `tekken.json` (or `None`).
+
+    Raises:
+        ImportError: If `mistral_format=True` and `mistral-common` is not installed.
+        OSError: If `mistral_format=True` and `tekken.json` cannot be found.
+    """
+    if mistral_format is False:
+        return (False, None)
+
+    if mistral_format is True:
+        if not is_mistral_common_available():
+            raise ImportError(
+                "mistral_format=True requires `mistral-common`. Install it with: pip install mistral-common"
+            )
+        tekken_file = cached_file(
+            pretrained_model_name_or_path,
+            "tekken.json",
+            _raise_exceptions_for_missing_entries=False,
+            _raise_exceptions_for_connection_errors=False,
+            **cache_kwargs,
+        )
+        if tekken_file is None:
+            raise OSError(
+                f"Cannot find 'tekken.json' at '{pretrained_model_name_or_path}'. "
+                "Set `mistral_format=False` to use standard HuggingFace files instead."
+            )
+        return (True, tekken_file)
+
+    # mistral_format is None: auto-detect
+    if not is_mistral_common_available():
+        return (False, None)
+
+    tekken_file = cached_file(
+        pretrained_model_name_or_path,
+        "tekken.json",
+        _raise_exceptions_for_missing_entries=False,
+        _raise_exceptions_for_connection_errors=False,
+        **cache_kwargs,
+    )
+    return (tekken_file is not None, tekken_file)
+
 
 _MAP_SPECIALS = {
     "bos_token": "<s>",
@@ -61,6 +143,20 @@ class MistralConverter:
         self.additional_special_tokens = additional_special_tokens
         self._precomputed_vocab: dict[str, int] | None = None
         self._precomputed_merges: list[tuple[str, str]] | None = None
+        self._tekken_metadata: dict[str, Any] | None = None
+
+    @property
+    def tekken_metadata(self) -> dict[str, Any]:
+        """Non-vocabulary metadata from the original ``tekken.json`` file.
+
+        Raises:
+            AttributeError: If the instance was not created via ``from_tekken_file``.
+        """
+        if self._tekken_metadata is None:
+            raise AttributeError(
+                "`tekken_metadata` is only accessible when instance is created by `from_tekken_file` method."
+            )
+        return self._tekken_metadata
 
     @classmethod
     def from_tekken_file(
@@ -109,6 +205,14 @@ class MistralConverter:
         # Store pre-computed vocab and merges so tokenizer() can use them directly
         instance._precomputed_vocab = vocab
         instance._precomputed_merges = merges
+
+        # Preserve tekken.json metadata so it can be reconstructed on save.
+        instance._tekken_metadata = {k: v for k, v in untyped.items() if k != "vocab"}
+        # Store which vocab entries had token_str=null so save_as_tekken can
+        # restore them instead of unconditionally decoding from bytes.
+        instance._tekken_metadata["_null_token_str_bytes"] = [
+            entry["token_bytes"] for entry in bpe_ranks_raw if entry.get("token_str") is None
+        ]
 
         return instance
 
@@ -176,3 +280,181 @@ class MistralConverter:
         tokenizer.post_processor = processors.ByteLevel(trim_offsets=False)
 
         return tokenizer
+
+
+def convert_tekken_tokenizer(tokenizer_file: str) -> PreTrainedTokenizerFast:
+    """Build a `PreTrainedTokenizerFast` from a Mistral `tekken.json` file.
+
+    Args:
+        tokenizer_file (`str`): Path to the `tekken.json` vocabulary file.
+
+    Returns:
+        Configured fast tokenizer with BPE model and special token mappings.
+    """
+    converter = MistralConverter.from_tekken_file(vocab_file=tokenizer_file, add_prefix_space=False)
+    fast = PreTrainedTokenizerFast(
+        tokenizer_object=converter.converted(),
+        tekken_metadata=converter.tekken_metadata,
+        **_MAP_SPECIALS,
+    )
+    return fast
+
+
+def _unicode_to_bytes() -> dict[str, int]:
+    """Invert `bytes_to_unicode()` to map unicode chars back to byte values."""
+    return {v: k for k, v in bytes_to_unicode().items()}
+
+
+def _bpe_token_to_bytes(token_str: str, decoder: dict[str, int]) -> bytes:
+    """Convert a BPE unicode token string back to raw bytes."""
+    return bytes(decoder[ch] for ch in token_str)
+
+
+def save_as_tekken(
+    tokenizer: PreTrainedTokenizerFast,
+    save_directory: str | Path,
+) -> Path:
+    """Reconstruct a `tekken.json` file from an HF tokenizer with stored tekken metadata.
+
+    The tokenizer must have been originally loaded from a `tekken.json` file and
+    must carry a `tekken_metadata` key in its `init_kwargs` (set automatically by
+    `convert_tekken_tokenizer`).
+
+    Args:
+        tokenizer (`PreTrainedTokenizerFast`): HF fast tokenizer with `tekken_metadata` in init_kwargs.
+        save_directory (`str | Path`): Directory to write the `tekken.json` file to.
+
+    Returns:
+        Path to the written `tekken.json` file.
+
+    Raises:
+        ValueError: If the tokenizer does not carry tekken metadata.
+    """
+    metadata = getattr(tokenizer, "tekken_metadata", None) or tokenizer.init_kwargs.get("tekken_metadata")
+    if metadata is None:
+        raise ValueError(
+            "Tokenizer does not carry `tekken_metadata`. "
+            "It was not loaded from a tekken.json file or metadata was lost."
+        )
+
+    save_directory = Path(save_directory)
+    save_directory.mkdir(parents=True, exist_ok=True)
+
+    decoder = _unicode_to_bytes()
+
+    hf_vocab: dict[str, int] = tokenizer.get_vocab()
+
+    # Separate special tokens (low ids) from BPE tokens.
+    special_tokens_metadata = metadata.get("special_tokens", [])
+    special_token_strs = {st["token_str"] for st in special_tokens_metadata}
+
+    bpe_entries: list[tuple[int, str]] = []
+    for token_str, token_id in hf_vocab.items():
+        if token_str in special_token_strs:
+            continue
+        bpe_entries.append((token_id, token_str))
+
+    bpe_entries.sort(key=lambda x: x[0])
+
+    null_token_str_bytes = set(metadata.get("_null_token_str_bytes", []))
+
+    vocab_list: list[dict] = []
+    for rank, (_token_id, token_str) in enumerate(bpe_entries):
+        try:
+            raw_bytes = _bpe_token_to_bytes(token_str, decoder)
+        except KeyError:
+            raw_bytes = token_str.encode("utf-8")
+        token_bytes_b64 = base64.b64encode(raw_bytes).decode("ascii")
+        vocab_list.append(
+            {
+                "rank": rank,
+                "token_bytes": token_bytes_b64,
+                "token_str": None
+                if token_bytes_b64 in null_token_str_bytes
+                else raw_bytes.decode("utf-8", errors="replace"),
+            }
+        )
+
+    tekken_data: dict = {}
+    tekken_data["vocab"] = vocab_list
+    tekken_data["special_tokens"] = special_tokens_metadata
+    if "config" in metadata:
+        tekken_data["config"] = metadata["config"]
+    if "version" in metadata:
+        tekken_data["version"] = metadata["version"]
+    if "type" in metadata:
+        tekken_data["type"] = metadata["type"]
+    for optional_key in ("image", "audio", "multimodal"):
+        if optional_key in metadata and metadata[optional_key] is not None:
+            tekken_data[optional_key] = metadata[optional_key]
+
+    output_path = save_directory / "tekken.json"
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(tekken_data, f, ensure_ascii=False)
+
+    return output_path
+
+
+def convert_tekken_image_processor(
+    tokenizer_file: str,
+    params_file: str,
+    chat_template: str | None = None,
+) -> "PixtralProcessor":
+    """Build a `PixtralProcessor` from a tekken tokenizer file and a native `params.json`.
+
+    Args:
+        tokenizer_file (`str`): Path to the `tekken.json` vocabulary file.
+        params_file (`str`): Path to the native `params.json` config file.
+        chat_template (`str | None`): Optional chat template string for the processor.
+
+    Returns:
+        Configured `PixtralProcessor` with tokenizer and image processor.
+
+    Raises:
+        ValueError: If `params_file` does not contain a `vision_encoder` key.
+    """
+    with open(params_file, encoding="utf-8") as f:
+        params = json.load(f)
+
+    vision_config = params.get("vision_encoder")
+    if vision_config is None:
+        raise ValueError(
+            f"'vision_encoder' key not found in {params_file}. "
+            "This model does not appear to be a vision-language model and does not need a processor. "
+            "Use `convert_tekken_tokenizer` for text-only models instead."
+        )
+
+    # Lazy imports: processing_pixtral imports from integrations.mistral at module level,
+    # so importing it here avoids a circular dependency. Placed after validation to avoid
+    # triggering heavy imports (torchvision) for text-only models that will fail anyway.
+    from ...models.pixtral.image_processing_pixtral import PixtralImageProcessor
+    from ...models.pixtral.processing_pixtral import PixtralProcessor
+
+    patch_size = vision_config["patch_size"]
+    max_image_size = vision_config.get("max_image_size", vision_config["image_size"])
+    spatial_merge_size = vision_config.get("spatial_merge_size", 2)
+
+    if is_mistral_common_available():
+        from ...tokenization_mistral_common import MistralCommonBackend
+
+        tokenizer = MistralCommonBackend(tokenizer_path=tokenizer_file)
+    else:
+        tokenizer = convert_tekken_tokenizer(tokenizer_file)
+
+    image_processor = PixtralImageProcessor(
+        patch_size=patch_size,
+        size={"longest_edge": max_image_size},
+    )
+
+    processor = PixtralProcessor(
+        tokenizer=tokenizer,
+        image_processor=image_processor,
+        image_token="[IMG]",
+        image_break_token="[IMG_BREAK]",
+        image_end_token="[IMG_END]",
+        patch_size=patch_size,
+        spatial_merge_size=spatial_merge_size,
+        chat_template=chat_template,
+    )
+
+    return processor

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -205,6 +205,7 @@ class TokenizersBackend(PreTrainedTokenizerBase):
 
             converter = MistralConverter.from_tekken_file(vocab_file)
             local_kwargs["tokenizer_object"] = converter.converted()
+            local_kwargs["tekken_metadata"] = converter.tekken_metadata
             return local_kwargs
 
         # SentencePiece model (with TikToken fallback)

--- a/tests/integrations/mistral/test_tokenizer.py
+++ b/tests/integrations/mistral/test_tokenizer.py
@@ -12,18 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for MistralConverter: tekken.json parsing and HuggingFace tokenizer conversion."""
+"""Tests for Mistral tekken tokenizer detection, conversion, and save utilities."""
 
 import base64
 import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from huggingface_hub import hf_hub_download
 from parameterized import parameterized
 
-from transformers.integrations.mistral import MistralConverter
+from transformers import AutoTokenizer
+from transformers.integrations.mistral import (
+    MistralConverter,
+    convert_tekken_tokenizer,
+    resolve_mistral_format,
+    save_as_tekken,
+)
+from transformers.integrations.mistral.tokenizer import convert_tekken_image_processor
 from transformers.testing_utils import require_mistral_common, slow
 from transformers.utils.import_utils import is_mistral_common_available
 
@@ -128,6 +136,30 @@ def _build_fake_tekken_json(
     return output_path
 
 
+class TestResolveMistralFormat(unittest.TestCase):
+    def test_false_returns_false_none(self):
+        result = resolve_mistral_format("fake/path", mistral_format=False)
+        self.assertEqual(result, (False, None))
+
+    def test_none_without_tekken_file_returns_false(self):
+        # Use a real local directory that has no tekken.json
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            use, path = resolve_mistral_format(tmp_dir, mistral_format=None)
+            self.assertFalse(use)
+
+    @patch("transformers.integrations.mistral.tokenizer.is_mistral_common_available", return_value=True)
+    def test_true_without_tekken_file_raises_helpful_error(self, _mock):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self.assertRaises(OSError) as ctx:
+                resolve_mistral_format(tmp_dir, mistral_format=True)
+            self.assertIn("mistral_format=False", str(ctx.exception))
+
+    @patch("transformers.integrations.mistral.tokenizer.is_mistral_common_available", return_value=False)
+    def test_true_without_mistral_common_raises(self, _mock):
+        with self.assertRaises(ImportError):
+            resolve_mistral_format("fake/path", mistral_format=True)
+
+
 class TestMistralConverter(unittest.TestCase):
     """Unit tests for MistralConverter using a synthetic tekken.json."""
 
@@ -145,6 +177,7 @@ class TestMistralConverter(unittest.TestCase):
     def test_from_tekken_file_sets_precomputed_fields(self):
         self.assertIsNotNone(self._converter._precomputed_vocab)
         self.assertIsNotNone(self._converter._precomputed_merges)
+        self.assertIsNotNone(self._converter._tekken_metadata)
 
     def test_converted_produces_working_tokenizer(self):
         ids = self._tokenizer.encode("a b c").ids
@@ -164,6 +197,19 @@ class TestMistralConverter(unittest.TestCase):
 
     def test_vocab_size(self):
         self.assertEqual(self._tokenizer.get_vocab_size(), _FULL_BYTE_VOCAB)
+
+    def test_tekken_metadata_content(self):
+        metadata = self._converter.tekken_metadata
+        self.assertEqual(metadata["version"], 1)
+        self.assertEqual(metadata["type"], "tekken")
+        self.assertIn("config", metadata)
+        self.assertEqual(metadata["config"]["version"], "v3")
+        self.assertNotIn("vocab", metadata, "Metadata should not contain the vocab itself")
+
+    def test_tekken_metadata_raises_without_from_file(self):
+        converter = MistralConverter()
+        with self.assertRaises(AttributeError):
+            _ = converter.tekken_metadata
 
     def test_special_tokens_assigned_by_rank_not_list_order(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -197,6 +243,185 @@ class TestMistralConverter(unittest.TestCase):
                     entry["rank"],
                     f"Special token {entry['token_str']!r} got wrong id",
                 )
+
+
+class TestConvertTekkenTokenizer(unittest.TestCase):
+    def test_basic_conversion(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = _build_fake_tekken_json(tmp_path)
+
+            tokenizer = convert_tekken_tokenizer(str(tekken_path))
+            self.assertIsNotNone(tokenizer)
+            self.assertEqual(tokenizer.vocab_size, _FULL_BYTE_VOCAB)
+
+    def test_tekken_metadata_preserved(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = _build_fake_tekken_json(tmp_path)
+
+            tokenizer = convert_tekken_tokenizer(str(tekken_path))
+            metadata = tokenizer.init_kwargs.get("tekken_metadata")
+            self.assertIsNotNone(metadata, "tekken_metadata not stored in init_kwargs")
+            self.assertEqual(metadata["config"]["version"], "v3")
+            self.assertEqual(metadata["version"], 1)
+            self.assertEqual(metadata["type"], "tekken")
+            self.assertIn("pattern", metadata["config"])
+
+    def test_special_tokens_set(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = _build_fake_tekken_json(tmp_path)
+
+            tokenizer = convert_tekken_tokenizer(str(tekken_path))
+            self.assertEqual(tokenizer.bos_token, "<s>")
+            self.assertEqual(tokenizer.eos_token, "</s>")
+            self.assertEqual(tokenizer.pad_token, "<pad>")
+            self.assertEqual(tokenizer.unk_token, "<unk>")
+
+
+class TestSaveAsTekken(unittest.TestCase):
+    def test_missing_metadata_raises(self):
+        tokenizer = MagicMock()
+        tokenizer.tekken_metadata = None
+        tokenizer.init_kwargs = {}
+
+        with self.assertRaisesRegex(ValueError, "tekken_metadata"):
+            save_as_tekken(tokenizer, "/tmp/opencode/test_save")
+
+    def test_roundtrip_tekken_to_hf_to_tekken(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_dir = tmp_path / "tekken"
+            tekken_dir.mkdir()
+            hf_dir = tmp_path / "hf"
+            hf_dir.mkdir()
+            reconstructed_dir = tmp_path / "reconstructed"
+            reconstructed_dir.mkdir()
+
+            tekken_path = _build_fake_tekken_json(tekken_dir)
+            original_tok = convert_tekken_tokenizer(str(tekken_path))
+            original_tok.save_pretrained(str(hf_dir))
+
+            reloaded_tok = AutoTokenizer.from_pretrained(str(hf_dir))
+            save_as_tekken(reloaded_tok, reconstructed_dir)
+
+            self.assertTrue((reconstructed_dir / "tekken.json").exists())
+
+            with open(tekken_path, encoding="utf-8") as f:
+                original = json.load(f)
+            with open(reconstructed_dir / "tekken.json", encoding="utf-8") as f:
+                reconstructed = json.load(f)
+
+            self.assertEqual(original, reconstructed)
+
+    def test_multimodal_metadata_preserved(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            image_config = {
+                "image_patch_size": 16,
+                "max_image_size": 1024,
+                "spatial_merge_size": 2,
+            }
+            tekken_path = _build_fake_tekken_json(tmp_path, image_config=image_config)
+
+            tok = convert_tekken_tokenizer(str(tekken_path))
+            metadata = tok.init_kwargs["tekken_metadata"]
+            self.assertEqual(metadata["image"], image_config)
+
+            reconstructed_dir = tmp_path / "reconstructed"
+            save_as_tekken(tok, reconstructed_dir)
+
+            with open(reconstructed_dir / "tekken.json", encoding="utf-8") as f:
+                reconstructed = json.load(f)
+
+            self.assertEqual(reconstructed["image"], image_config)
+
+    def test_creates_output_directory(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = _build_fake_tekken_json(tmp_path)
+            tok = convert_tekken_tokenizer(str(tekken_path))
+
+            new_dir = tmp_path / "nonexistent" / "nested"
+            output_path = save_as_tekken(tok, new_dir)
+            self.assertTrue(output_path.exists())
+            self.assertEqual(output_path.name, "tekken.json")
+
+
+class TestConvertTekkenImageProcessor(unittest.TestCase):
+    def test_missing_vision_encoder_raises(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = _build_fake_tekken_json(tmp_path)
+            params_path = tmp_path / "params.json"
+            with open(params_path, "w", encoding="utf-8") as f:
+                json.dump({"dim": 128, "n_heads": 2}, f)
+
+            with self.assertRaisesRegex(ValueError, "vision_encoder"):
+                convert_tekken_image_processor(str(tekken_path), str(params_path))
+
+    def _make_params(self, tmp_path, vision_encoder, **extra):
+        params_path = tmp_path / "params.json"
+        data = {**extra, "vision_encoder": vision_encoder}
+        with open(params_path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+        return params_path
+
+    def test_valid_processor_creation(self):
+        from transformers.models.pixtral.image_processing_pixtral import PixtralImageProcessor
+        from transformers.models.pixtral.processing_pixtral import PixtralProcessor
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = _build_fake_tekken_json(tmp_path)
+            params_path = self._make_params(
+                tmp_path,
+                vision_encoder={"patch_size": 16, "image_size": 1024, "spatial_merge_size": 2},
+            )
+
+            processor = convert_tekken_image_processor(str(tekken_path), str(params_path))
+
+            # Processor type and sub-components
+            self.assertIsInstance(processor, PixtralProcessor)
+            self.assertIsInstance(processor.image_processor, PixtralImageProcessor)
+            self.assertIsNotNone(processor.tokenizer)
+
+            # Vision parameters forwarded correctly
+            self.assertEqual(processor.patch_size, 16)
+            self.assertEqual(processor.spatial_merge_size, 2)
+            self.assertEqual(processor.image_processor.patch_size, 16)
+            self.assertEqual(processor.image_processor.size, {"longest_edge": 1024})
+
+            # Hardcoded image tokens
+            self.assertEqual(processor.image_token, "[IMG]")
+            self.assertEqual(processor.image_break_token, "[IMG_BREAK]")
+            self.assertEqual(processor.image_end_token, "[IMG_END]")
+
+    def test_max_image_size_overrides_image_size(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = _build_fake_tekken_json(tmp_path)
+            params_path = self._make_params(
+                tmp_path,
+                vision_encoder={"patch_size": 16, "image_size": 512, "max_image_size": 2048},
+            )
+
+            processor = convert_tekken_image_processor(str(tekken_path), str(params_path))
+            self.assertEqual(processor.image_processor.size, {"longest_edge": 2048})
+
+    def test_chat_template_forwarded(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            tekken_path = _build_fake_tekken_json(tmp_path)
+            params_path = self._make_params(
+                tmp_path,
+                vision_encoder={"patch_size": 16, "image_size": 1024},
+            )
+            template = "{% for m in messages %}{{ m.content }}{% endfor %}"
+
+            processor = convert_tekken_image_processor(str(tekken_path), str(params_path), chat_template=template)
+            self.assertEqual(processor.chat_template, template)
 
 
 @require_mistral_common
@@ -399,6 +624,33 @@ class TestMistralConverterIntegration(unittest.TestCase):
                 hf_decoded = hf_tokenizer.decode([token_id], skip_special_tokens=True)
                 mc_decoded = mc_tokenizer.decode([token_id], skip_special_tokens=True)
                 self.assertEqual(hf_decoded, mc_decoded, f"Per-token decode mismatch for id={token_id} in {text!r}")
+
+
+@slow
+class TestSaveAsTekkenIntegration(unittest.TestCase):
+    """Round-trip a real tekken.json (with non-null token_str entries) through HF and back."""
+
+    def test_real_tekken_roundtrip_preserves_vocab_and_specials(self) -> None:
+        tekken_path = hf_hub_download(_INTEGRATION_REPOS[0], "tekken.json")
+        with open(tekken_path, encoding="utf-8") as f:
+            original = json.load(f)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            hf_dir = tmp_path / "hf"
+            reconstructed_dir = tmp_path / "reconstructed"
+
+            tok = convert_tekken_tokenizer(tekken_path)
+            tok.save_pretrained(str(hf_dir))
+            reloaded = AutoTokenizer.from_pretrained(str(hf_dir))
+            save_as_tekken(reloaded, reconstructed_dir)
+
+            with open(reconstructed_dir / "tekken.json", encoding="utf-8") as f:
+                reconstructed = json.load(f)
+
+        self.assertEqual(original["vocab"], reconstructed["vocab"])
+        self.assertEqual(original["special_tokens"], reconstructed["special_tokens"])
+        self.assertEqual(original.get("config"), reconstructed.get("config"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add core tekken tokenizer utilities on top of the `MistralConverter` package introduced in PR #1:

- **`resolve_mistral_format()`**: Tri-state detection (`True`/`False`/`None`) for choosing the `mistral-common` backend vs standard HF tokenizer, based on `tekken.json` presence and library availability.
- **`MISTRAL_MODEL_TYPES`**: Frozenset of model types eligible for Mistral-format handling.
- **`convert_tekken_tokenizer()`**: Build a `PreTrainedTokenizerFast` from a raw `tekken.json` file.
- **`save_as_tekken()`**: Reconstruct a `tekken.json` file from an HF tokenizer with stored tekken metadata (round-trip support).
- **`convert_tekken_processor()`**: Build a `PixtralProcessor` from native `tekken.json` + `params.json` files.

## Files changed

- `src/transformers/integrations/mistral/__init__.py` — export new symbols
- `src/transformers/integrations/mistral/tokenizer.py` — add utilities
- `tests/integrations/mistral/test_tokenizer.py` — add tests

Stacked on `mistral/01-package-converter`.
